### PR TITLE
Mute game audio in ending

### DIFF
--- a/Main.bb
+++ b/Main.bb
@@ -4172,6 +4172,8 @@ Function DrawEnding()
 		;EndIf
 		
 		If EndingScreen = 0 Then
+			KillSounds()
+
 			SubBox\screenTop = GraphicHeight * 0.9
 			RecalculateSubtitleBoxTarget()
 


### PR DESCRIPTION
Normally, all sfx will continue to play in the ending screen until the ending audio begins. This ensures that it kills all sounds.